### PR TITLE
Fix crash on missing svgLoader

### DIFF
--- a/rewireWebpack.js
+++ b/rewireWebpack.js
@@ -67,8 +67,11 @@ const rewireTypescript = config => {
 
   // Replace the preset in the SVG loader for the same reason as above.
   const svgLoader = getLoader(config.module.rules, svgLoaderMatcher);
-  const svgBabelLoader = svgLoader.use.find(l => /babel-loader/.test(l.loader));
-  svgBabelLoader.options.presets = babelLoader.options.presets;
+  
+  if (svgLoader) {
+    const svgBabelLoader = svgLoader.use.find(l => /babel-loader/.test(l.loader));
+    svgBabelLoader.options.presets = babelLoader.options.presets;
+  }
 
   return config;
 };


### PR DESCRIPTION
Hey, thanks for this awesome package! It's been working great, but I just downloaded the newest `react-scripts@next` (`^2.0.0-next.47d2d941`) and `npm start` was crashing with "cannot read property 'use' of undefined". I assume they've removed the svg loader? This change fixed it for me.