### PR TITLE
Correctly resolve entry point when inside monorepo

### DIFF
--- a/rewireWebpack.js
+++ b/rewireWebpack.js
@@ -15,9 +15,9 @@ const projectDirectory = resolveProjectDirectory();
 // Switch out the entry point index.js for index.tsx.
 // We need to perform the monkey patching on the react-scripts path module
 // on import to intercept the preflight checking.
-reactScriptsPathsModule.appIndexJs = path.resolve(
-  projectDirectory,
-  "src/index.tsx"
+reactScriptsPathsModule.appIndexJs = require.resolve(
+  "src/index.tsx",
+  { paths: [projectDirectory, process.cwd()] }
 );
 
 // Matcher to find JavaScript/JSX loader using getLoader util from


### PR DESCRIPTION
I'm using this inside a lerna repo with yarn workspaces. I have hoisting enabled so the folder where my CRA app resides doesn't contain a `node_modules` folder. This breaks your current implementation because it's looking for `src/index.tsx` inside of the `node_modules` at the root of my lerna repo (because that's where `react-scripts` was hoisted to).

In other words, it's trying to resolve: `<lernaRoot>/src/index.tsx`
The file is actually located at: `<lernaRoot>/packages/<cra-app>/src/index.tsx`

I've used [`require.resolve()`](https://nodejs.org/api/modules.html#modules_require_resolve_request_options) because it allows to try resolving from multiple paths. I've put the original path first, so this shouldn't be a breaking change.

I've used [`process.cwd()`](https://nodejs.org/api/process.html#process_process_cwd) as the fallback path because that is the directory where the `react-app-rewired` command was run, which in a standard setup would be the CRA app's root folder. This will also work in cases where there are multiple CRA apps in one monorepo (and hence potentially multiple `react-scripts` folders)

I tested this with my setup and it worked fine.

I'm working on a PR to CRA to remove the hard-coded '.js' extension on the entry point so that this whole part of the code would be unnecessary. At that point, just adding `".ts", ".tsx"` to webpack's `resolve.extensions` (which you're already doing) would be sufficient.

I'll make another PR here if/when I'm able to get that merged at CRA. In the meantime, this patch should suffice for people using any type of monorepo structure.

Let me know if you have any questions or concerns.