### PR TITLE
Fix flow removal by taking advantage of 'flow' option

### DIFF
--- a/rewirePreset.js
+++ b/rewirePreset.js
@@ -4,10 +4,7 @@ const removeFlowPreset = (...args) => {
   // Pass along arguments to babel-preset-react-app and generate its preset.
   const preset = presetReactApp(...args);
 
-  // Replace the Flow preset with TypeScript.
-  preset.presets = preset.presets.filter(
-    p => !/FlowStripTypes/.test(p.toString())
-  );
+  // Add typescript preset to react-app preset's list of presets
   preset.presets.push("@babel/preset-typescript");
 
   return preset;

--- a/rewirePreset.js
+++ b/rewirePreset.js
@@ -4,7 +4,10 @@ const removeFlowPreset = (...args) => {
   // Pass along arguments to babel-preset-react-app and generate its preset.
   const preset = presetReactApp(...args);
 
-  // Add typescript preset to react-app preset's list of presets
+  // Replace the Flow preset with TypeScript.
+  preset.presets = preset.presets.filter(
+    p => !/FlowStripTypes/.test(p.toString())
+  );
   preset.presets.push("@babel/preset-typescript");
 
   return preset;

--- a/rewireWebpack.js
+++ b/rewireWebpack.js
@@ -63,7 +63,9 @@ const rewireTypescript = config => {
 
   // Replace the babel-preset-react-app preset with the preset rewire from this
   // package. This is done so @babel/preset-flow can be removed.
-  babelLoader.options.presets = [path.resolve(__dirname, "rewirePreset")];
+  babelLoader.options.presets = [
+    [path.resolve(__dirname, "rewirePreset"), { flow: false }]
+  ];
 
   // Replace the preset in the SVG loader for the same reason as above.
   const svgLoader = getLoader(config.module.rules, svgLoaderMatcher);


### PR DESCRIPTION
With the newest version of `react-scripts` that just released today (`2.0.0-next.b2fd8db8`), your preset stopped working. I was getting this: `Error: "Cannot combine flow and typescript plugins"`.

I was able to get it working again by making use of the `flow` option described [here](https://github.com/facebook/create-react-app/tree/next/packages/babel-preset-react-app#usage-with-typescript). This made the code I removed in my PR unnecessary. However, according to [this comment](https://github.com/facebook/create-react-app/pull/3865#issuecomment-361667191), the `flow` option wasn't available in `babel-preset-react-app` until possibly the most recent 1 or 2 beta releases, so I'm not sure if you want to keep the code I removed in there for backwards compatibility with people who may be using your preset with one of the older versions, or just make it a potentially breaking change and recommend that people update to the newest beta release of `react-scripts`. I have verified that it works with the version of `react-scripts` released today.

Feel free to make any changes as you see fit. Thanks again for this great preset!