### PR TITLE
Give *ts* extensions higher precedence than existing extensions

### DIFF
--- a/packages/rewire/rewireWebpack.ts
+++ b/packages/rewire/rewireWebpack.ts
@@ -15,7 +15,7 @@ export default function(c: webpack.Configuration): webpack.Configuration {
   // Validate and narrow type
   const config = getValidatedConfig(c);
 
-  config.resolve.extensions.push(".web.ts", ".web.tsx", ".ts", ".tsx");
+  config.resolve.extensions.unshift(".web.ts", ".web.tsx", ".ts", ".tsx");
 
   // Locate the Webpack loader responsible for handling Javascript assets and
   // add TypeScript file extensions.


### PR DESCRIPTION
I have a somewhat complex project structure involving a Lerna mono-repo with isomorphic packages using ES Modules (`"target": "esnext"` and `"module": "none"` in `tsconfig.json` & running with `node --experimental-modules index.js` after building). I'm just now getting to a point where I'm ready to build for production for the first time.

If I build CRA first everything is cool, but if I try to build it *after* building my isomorphic packages and server, the CRA build tries to use the precompiled `.js` files, compiles with a bunch of warnings, and then breaks at runtime.

I *could* make `clean` scripts to remove the `.js` files everywhere and each time I build run those first, then build CRA, then build everything else. It'd be much nicer though if CRA would just use the original `.ts` files, even with the existence of some `.js` files. That's what this PR accomplishes. I don't know what other effects this may have in other workflows, but it works for my use case so I figured I'd present it for your consideration. :)