### PR TITLE
Add tsExtHighPriority option

### DIFF
--- a/packages/rewire/rewireWebpack.ts
+++ b/packages/rewire/rewireWebpack.ts
@@ -11,47 +11,67 @@ reactScriptsPaths.appIndexJs = reactScriptsPaths.appIndexJs.replace(
   `src${path.sep}index.tsx`
 );
 
-export default function(c: webpack.Configuration): webpack.Configuration {
-  // Validate and narrow type
-  const config = getValidatedConfig(c);
+export type CreateRewireWebpack = (
+  options: { tsExtHighPriority: boolean }
+) => RewireWebpack;
 
-  config.resolve.extensions.unshift(".web.ts", ".web.tsx", ".ts", ".tsx");
+export type RewireWebpack = (c: webpack.Configuration) => webpack.Configuration;
 
-  // Locate the Webpack loader responsible for handling Javascript assets and
-  // add TypeScript file extensions.
-  const scriptLoader = getLoader(config.module.rules, scriptsLoaderMatcher);
-  if (!scriptLoader) throw new Error("Unable to locate scripts loader.");
-  scriptLoader.test = /\.(ts|tsx|js|jsx|mjs)$/;
+export interface RewireWebpackWithOptions extends RewireWebpack {
+  withOptions?: CreateRewireWebpack;
+}
 
-  // Replace the babel-preset-react-app preset with the preset rewire from this
-  // package. This is done so @babel/preset-flow can be removed.
-  const babelLoader = getBabelLoader(config.module.rules) as webpack.NewLoader;
-  if (!babelLoader || !babelLoader.options)
-    throw new Error("Unable to locate Babel loader.");
-  babelLoader.options.presets = [path.resolve(__dirname, "rewirePreset")];
+const rewireWebpack = createRewireWebpack();
+(rewireWebpack as RewireWebpackWithOptions).withOptions = createRewireWebpack;
 
-  // Older versions of react-scripts v2 use a Webpack loader to add support for
-  // SVGs as React components. Later versions do this using a Babel plugin.
-  // Check if it is present. If it is, replace the preset in the SVG loader's
-  // sibling Babel loader.
-  const svgLoader = getLoader(config.module.rules, svgLoaderMatcher);
-  if (svgLoader) {
-    if (!("use" in svgLoader) || !Array.isArray(svgLoader.use))
-      throw new Error("Unexpected layout for SVG loader.");
-    const svgBabelLoader = svgLoader.use.find((l: any) =>
-      /babel-loader/.test(l.loader)
-    );
-    if (
-      !svgBabelLoader ||
-      typeof svgBabelLoader !== "object" ||
-      !("options" in svgBabelLoader) ||
-      svgBabelLoader.options == null
-    )
-      throw new Error("Unable to locate sibling Babel loader in SVG loader.");
-    svgBabelLoader.options.presets = babelLoader.options.presets;
-  }
+export default rewireWebpack;
 
-  return config;
+function createRewireWebpack(options = { tsExtHighPriority: false }) {
+  return (c => {
+    // Validate and narrow type
+    const config = getValidatedConfig(c);
+
+    const arrAddFn = options.tsExtHighPriority ? "unshift" : "push";
+    config.resolve.extensions[arrAddFn](".web.ts", ".web.tsx", ".ts", ".tsx");
+
+    // Locate the Webpack loader responsible for handling Javascript assets and
+    // add TypeScript file extensions.
+    const scriptLoader = getLoader(config.module.rules, scriptsLoaderMatcher);
+    if (!scriptLoader) throw new Error("Unable to locate scripts loader.");
+    scriptLoader.test = /\.(ts|tsx|js|jsx|mjs)$/;
+
+    // Replace the babel-preset-react-app preset with the preset rewire from this
+    // package. This is done so @babel/preset-flow can be removed.
+    const babelLoader = getBabelLoader(
+      config.module.rules
+    ) as webpack.NewLoader;
+    if (!babelLoader || !babelLoader.options)
+      throw new Error("Unable to locate Babel loader.");
+    babelLoader.options.presets = [path.resolve(__dirname, "rewirePreset")];
+
+    // Older versions of react-scripts v2 use a Webpack loader to add support for
+    // SVGs as React components. Later versions do this using a Babel plugin.
+    // Check if it is present. If it is, replace the preset in the SVG loader's
+    // sibling Babel loader.
+    const svgLoader = getLoader(config.module.rules, svgLoaderMatcher);
+    if (svgLoader) {
+      if (!("use" in svgLoader) || !Array.isArray(svgLoader.use))
+        throw new Error("Unexpected layout for SVG loader.");
+      const svgBabelLoader = svgLoader.use.find((l: any) =>
+        /babel-loader/.test(l.loader)
+      );
+      if (
+        !svgBabelLoader ||
+        typeof svgBabelLoader !== "object" ||
+        !("options" in svgBabelLoader) ||
+        svgBabelLoader.options == null
+      )
+        throw new Error("Unable to locate sibling Babel loader in SVG loader.");
+      svgBabelLoader.options.presets = babelLoader.options.presets;
+    }
+
+    return config;
+  }) as RewireWebpack;
 }
 
 // Matcher to find JavaScript/JSX loader using getLoader util from


### PR DESCRIPTION
Adding the actual option functionality was easy but making typescript and the linter happy, not so much.. lol

Anyway, it works perfectly. I ran first without changing anything in my "consuming" app. It predictably compiled with warnings and failed. Next I used the new `withOptions` property in `config-overrides.js` to set the new option to true, ran my build again, and it worked fine.

The relevant change (only needed if you don't want the default behavior) in the app-side code is this:
```javascript
- return rewireTypescript(config);
+ return rewireTypescript.withOptions({ tsExtHighPriority: true })(config);
```

Sorry it took longer than expected, thanks for being patient!