### PR TITLE
feat: allow babelrc in babel-jest transformer

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -162,3 +162,25 @@ $ npm install --save-dev typescript
 ```
 
 ?> You'll also need to add the `noEmit` option to your `tsconfig.json` to prevent your source files from being compiled. See the above sample.
+
+## Jest
+
+#### Babel
+
+When using Jest, your code is not compiled via Webpack. Any changes made in `config-overrides.js` to Webpack's Babel config will **not** be applied when running tests in Jest.
+
+If you need to load Babel plugins/presets during testing, set up an external Babel config (see: https://babeljs.io/docs/en/next/configuration.html).
+
+You can ensure this config only targets the "test" environment:
+
+```json
+{
+  "env": {
+    "test": {
+      "plugins": [
+        "emotion"
+      ]
+    }
+  }
+}
+```

--- a/packages/rewire/rewireBabelTransform.ts
+++ b/packages/rewire/rewireBabelTransform.ts
@@ -11,7 +11,7 @@ import babelJest from "./rewireBabelJest";
 
 const transformer = babelJest.createTransformer({
   presets: [path.resolve(__dirname, "rewirePreset")],
-  babelrc: false
+  babelrc: true
 });
 
 // Not using a default export here on purpose to match the export structure


### PR DESCRIPTION
Fixes #18 

Verified that this fixes the outlined issue by testing with the `example` project.

Ran `yarn add emotion react-emotion babel-plugin-emotion`. Defined a styled component in a way that requires the Babel plugin:

```
const Box = styled.div`
  background-color: green;
`
```

Added this component to the body of `App.tsx`.

Ran `yarn start`. It fails to compile because of missing Babel plugin. Updated `config-overrides.js` with an `injectBabelPlugin()` helper for the emotion plugin. Verified app now works.

Ran `yarn test`. It fails to compile because of missing Babel plugin. Created a root `.babelrc` file and copy-pasted json config example I used in the docs. Verified test now works.