### PR TITLE
docs(installation): added @babel/preset-typescript

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,6 +18,7 @@ Install the following packages:
 
 - react-app-rewired@next
 - react-app-rewire-typescript-babel-preset
+- @babel/preset-typescript
 - @types/react
 - @types/react-dom
 - @types/jest
@@ -28,13 +29,13 @@ is needed to properly support `react-scripts` v2.
 #### NPM
 
 ```shell
-npm install --save-dev react-app-rewired@next react-app-rewire-typescript-babel-preset @types/react @types/react-dom @types/jest
+npm install --save-dev react-app-rewired@next react-app-rewire-typescript-babel-preset @babel/preset-typescript @types/react @types/react-dom @types/jest
 ```
 
 #### Yarn
 
 ```shell
-yarn add --dev react-app-rewired@next react-app-rewire-typescript-babel-preset @types/react @types/react-dom @types/jest
+yarn add --dev react-app-rewired@next react-app-rewire-typescript-babel-preset @babel/preset-typescript @types/react @types/react-dom @types/jest
 ```
 
 ## TSLint


### PR DESCRIPTION
Added `@babel/preset-typescript` as a dependency on the installation docs

Question: Should we add a disclaimer on the `@babel/preset-typescript` part of the `Additional Packages` section pointing to the [Issues and limitations](https://react-app-rewire-typescript-babel-preset.netlify.com/#/docs/limitations?id=issues-and-limitations)? Something like `(see [Issues and limitations](https://react-app-rewire-typescript-babel-preset.netlify.com/#/docs/limitations?id=issues-and-limitations) to know more)`

closes #21 